### PR TITLE
feat(layout): sticky edge rails, full-bleed pages, global scroll-to-top FAB

### DIFF
--- a/fe/src/App.vue
+++ b/fe/src/App.vue
@@ -23,6 +23,8 @@
     <!-- Global Command Palette & Notifications -->
     <CommandPalette />
     <ToastNotification />
+    <!-- Scroll to Top FAB (public pages only) -->
+    <ScrollToTopButton v-if="!isAdminRoute" />
   </div>
 </template>
 
@@ -35,6 +37,7 @@ import Navbar from '@/components/layout/Navbar.vue'
 import Footer from '@/components/layout/Footer.vue'
 import CommandPalette from '@/components/ui/CommandPalette.vue'
 import ToastNotification from '@/components/ui/ToastNotification.vue'
+import ScrollToTopButton from '@/components/ui/ScrollToTopButton.vue'
 import { useCommandPalette } from '@/composables/useCommandPalette'
 import { useSmoothScroll } from '@/composables/useSmoothScroll'
 

--- a/fe/src/components/ui/ScrollToTopButton.vue
+++ b/fe/src/components/ui/ScrollToTopButton.vue
@@ -1,0 +1,103 @@
+<template>
+  <Transition name="scroll-fab">
+    <button
+      v-if="visible"
+      type="button"
+      aria-label="Scroll to top"
+      class="scroll-fab"
+      @click="handleClick"
+    >
+      <svg
+        class="w-4 h-4"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.75"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="M8 13V3M3.5 7.5 8 3l4.5 4.5" />
+      </svg>
+    </button>
+  </Transition>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+
+const SCROLL_THRESHOLD = 300
+const visible = ref(false)
+
+function onScroll() {
+  visible.value = window.scrollY > SCROLL_THRESHOLD
+}
+
+function handleClick() {
+  window.scrollTo({ top: 0, behavior: 'smooth' })
+}
+
+onMounted(() => {
+  window.addEventListener('scroll', onScroll, { passive: true })
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('scroll', onScroll)
+})
+</script>
+
+<style scoped>
+.scroll-fab {
+  position: fixed;
+  bottom: 1.75rem;
+  right: 1.75rem;
+  z-index: 200;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-ink, #1a1a1a);
+  color: var(--color-surface, #f8f7f5);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow:
+    0 4px 16px rgba(0, 0, 0, 0.18),
+    0 1px 3px rgba(0, 0, 0, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  cursor: pointer;
+  transition:
+    transform 200ms cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 200ms ease,
+    opacity 200ms ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.scroll-fab:hover {
+  transform: translateY(-2px) scale(1.06);
+  box-shadow:
+    0 8px 24px rgba(0, 0, 0, 0.24),
+    0 2px 6px rgba(0, 0, 0, 0.16),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.scroll-fab:active {
+  transform: scale(0.93);
+}
+
+/* Transition: slide up + fade */
+.scroll-fab-enter-active {
+  transition:
+    opacity 260ms ease,
+    transform 300ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.scroll-fab-leave-active {
+  transition:
+    opacity 200ms ease,
+    transform 200ms ease;
+}
+.scroll-fab-enter-from,
+.scroll-fab-leave-to {
+  opacity: 0;
+  transform: translateY(12px) scale(0.88);
+}
+</style>

--- a/fe/src/views/AboutView.vue
+++ b/fe/src/views/AboutView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-[100dvh] bg-canvas">
-    <div class="max-w-5xl mx-auto px-4 sm:px-6 py-10 sm:py-14 space-y-16 sm:space-y-24">
+    <div class="w-full max-w-[1600px] mx-auto px-3 sm:px-6 py-10 sm:py-14 space-y-16 sm:space-y-24">
       <!-- ── Page Header: Avant-Garde Profile Architecture ───────────── -->
       <header class="editorial-card">
         <div class="editorial-card__inner p-8 sm:p-14 flex flex-col justify-between gap-8">
@@ -29,10 +29,10 @@
       <LoadingSpinner v-if="loading" />
 
       <template v-else>
-        <!-- ── Profile Card & Bio Overview: Asymmetric Split ─────────── -->
-        <div class="grid grid-cols-1 lg:grid-cols-12 gap-6 items-start">
-          <!-- Left Avatar Sidebar (Col 4) -->
-          <div class="lg:col-span-4 editorial-card lg:sticky lg:top-24">
+        <!-- ── Profile Card & Bio Overview: Edge-Anchored Sticky Left ──── -->
+        <div class="xl:grid xl:grid-cols-[220px_1fr] xl:items-start xl:gap-0">
+          <!-- Left Avatar Sticky Rail -->
+          <div class="xl:sticky xl:top-24 xl:self-start xl:pr-6 xl:pl-1 mb-8 xl:mb-0 editorial-card lg:editorial-card">
             <div class="editorial-card__inner p-7 flex flex-col items-center text-center space-y-5">
               <div class="relative w-36 h-36 rounded-2xl overflow-hidden bg-bone border border-stroke shadow-[inset_0_1px_1px_rgba(255,255,255,0.1)]">
                 <img
@@ -83,8 +83,8 @@
             </div>
           </div>
 
-          <!-- Right Bio Narrative & Quick Specs (Col 8) -->
-          <div class="lg:col-span-8 space-y-6">
+          <!-- Right Bio Narrative & Quick Specs -->
+          <div class="xl:min-w-0 xl:pl-8 space-y-6">
             <div class="editorial-card">
               <div class="editorial-card__inner p-8 sm:p-10 flex flex-col justify-between space-y-6">
                 <div class="flex items-center justify-between pb-3 border-b border-stroke">

--- a/fe/src/views/BlogView.vue
+++ b/fe/src/views/BlogView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-[100dvh] bg-canvas">
-    <div class="max-w-5xl mx-auto px-4 sm:px-6 py-8 sm:py-12 space-y-10 sm:space-y-12">
+    <div class="w-full max-w-[1600px] mx-auto px-3 sm:px-6 py-8 sm:py-12 space-y-10 sm:space-y-12">
       <!-- ── Page Header: Avant-Garde Editorial Architecture ─────────── -->
       <header class="editorial-card">
         <div class="editorial-card__inner p-8 sm:p-14 flex flex-col justify-between gap-8">
@@ -78,12 +78,17 @@
           v-for="(post, index) in blogStore.posts"
           :key="post._id"
           :class="[
-            index % 5 === 0 ? 'col-span-12 lg:col-span-8' : (index % 5 === 1 ? 'col-span-12 lg:col-span-4' : (index % 5 === 2 ? 'col-span-12 lg:col-span-4' : 'col-span-12 lg:col-span-8'))
+            index % 5 === 0 ? 'col-span-12 xl:col-span-7' :
+            index % 5 === 1 ? 'col-span-12 xl:col-span-5' :
+            index % 5 === 2 ? 'col-span-12 md:col-span-5 xl:col-span-4' :
+            index % 5 === 3 ? 'col-span-12 md:col-span-7 xl:col-span-8' :
+                               'col-span-12'
           ]"
         >
           <BlogCard :post="post" :layout="getMasonryLayout(index)" />
         </div>
       </div>
+
 
       <!-- Empty State -->
       <div v-else class="editorial-card">

--- a/fe/src/views/ProjectDetailView.vue
+++ b/fe/src/views/ProjectDetailView.vue
@@ -1,11 +1,12 @@
 <template>
   <div class="min-h-[100dvh] bg-canvas">
-    <div class="max-w-5xl mx-auto px-4 sm:px-6 py-8 sm:py-12 space-y-12">
+    <!-- Outer full-bleed wrapper -->
+    <div class="w-full max-w-[1720px] mx-auto px-3 sm:px-6 py-8 sm:py-12">
       <LoadingSpinner v-if="loading" />
 
-      <div v-else-if="project" class="space-y-10">
+      <div v-else-if="project" class="space-y-8">
         <!-- Top Nav & Breadcrumb Bar -->
-        <div class="flex items-center justify-between gap-4">
+        <div class="flex items-center justify-between gap-4 px-2">
           <RouterLink
             to="/projects"
             class="inline-flex items-center gap-2 text-ink-tertiary hover:text-ink transition-colors text-xs font-mono group active:scale-95"
@@ -45,58 +46,61 @@
                 {{ project.description }}
               </p>
             </div>
-
-            <!-- Header Quick Spec Strip -->
-            <div class="flex flex-wrap items-center justify-between gap-4 pt-6 border-t border-stroke text-xs font-mono">
-              <div class="flex flex-wrap items-center gap-2">
-                <span class="text-ink-tertiary">Core Technologies:</span>
-                <span
-                  v-for="tech in (project.technologies || []).slice(0, 5)"
-                  :key="tech"
-                  class="px-2.5 py-0.5 rounded-full bg-bone border border-stroke text-ink text-[11px]"
-                >
-                  {{ tech }}
-                </span>
-                <span v-if="(project.technologies || []).length > 5" class="text-ink-tertiary">
-                  +{{ project.technologies.length - 5 }} more
-                </span>
-              </div>
-
-              <div class="flex items-center gap-3">
-                <a
-                  v-if="project.liveUrl"
-                  :href="project.liveUrl"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="group inline-flex items-center gap-2 px-4 py-2 rounded-md bg-ink text-surface font-sans font-medium text-xs active:scale-[0.98] transition-all"
-                >
-                  <span>Launch Live App</span>
-                  <span class="w-4 h-4 rounded-full bg-surface/20 flex items-center justify-center group-hover:translate-x-0.5 group-hover:-translate-y-px transition-transform duration-200">
-                    <svg class="w-2.5 h-2.5" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
-                      <path d="M2.5 9.5 9.5 2.5M5 2.5h4.5V7"/>
-                    </svg>
-                  </span>
-                </a>
-
-                <a
-                  v-if="project.githubUrl"
-                  :href="project.githubUrl"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="px-3 py-2 rounded-md bg-bone border border-stroke text-ink-secondary hover:text-ink font-sans font-medium text-xs transition-colors"
-                >
-                  Repository
-                </a>
-              </div>
-            </div>
           </div>
         </header>
 
-        <!-- ── Main Showcase Grid: Asymmetric Split ────────────────────── -->
-        <div class="grid grid-cols-1 lg:grid-cols-12 gap-6 items-start">
+        <!-- ── 3-Column Sticky Rail Layout ────────────────────────────── -->
+        <!--
+          xl+:  [220px sticky left rail] [flex-1 center] [200px sticky right rail]
+          < xl: stacks single-column: left rail → center → right rail
+        -->
+        <div class="xl:grid xl:grid-cols-[220px_1fr_200px] xl:items-start xl:gap-0">
 
-          <!-- Left / Main Column: Media & Case Content (Col 8) -->
-          <div class="lg:col-span-8 space-y-8">
+          <!-- ── LEFT RAIL: System Spec Rail (sticky) ──────────────────── -->
+          <aside
+            class="xl:sticky xl:top-24 xl:self-start
+                   xl:pr-4 xl:pl-1
+                   space-y-4
+                   mb-6 xl:mb-0"
+          >
+            <div class="editorial-card">
+              <div class="editorial-card__inner p-5 space-y-5">
+                <div class="flex items-center justify-between pb-3 border-b border-stroke">
+                  <h2 class="text-[10px] font-mono uppercase tracking-widest text-ink-tertiary">System Spec Rail</h2>
+                  <span class="w-1.5 h-1.5 rounded-full" :class="project.liveUrl ? 'bg-pastel-green-text animate-pulse-soft' : 'bg-ink-tertiary'"></span>
+                </div>
+
+                <!-- Status & Lifecycle -->
+                <div class="grid grid-cols-1 gap-2 text-xs font-mono">
+                  <div class="p-3 rounded-lg bg-bone border border-stroke">
+                    <span class="text-[10px] text-ink-tertiary uppercase block">Status</span>
+                    <span class="text-ink mt-1 block font-medium">{{ project.liveUrl ? 'Active in Prod' : 'Completed' }}</span>
+                  </div>
+                  <div class="p-3 rounded-lg bg-bone border border-stroke">
+                    <span class="text-[10px] text-ink-tertiary uppercase block">Timeline</span>
+                    <span class="text-ink mt-1 block tabular-nums">{{ project.duration || '2025' }}</span>
+                  </div>
+                </div>
+
+                <!-- Category Tags -->
+                <div v-if="project.categories && project.categories.length" class="space-y-2">
+                  <span class="text-[10px] font-mono text-ink-tertiary uppercase tracking-wider block">Domain Classification</span>
+                  <div class="flex flex-wrap gap-1.5">
+                    <span
+                      v-for="cat in project.categories"
+                      :key="cat"
+                      class="px-2.5 py-1 rounded-full bg-pastel-blue text-pastel-blue-text text-[10px] font-mono tracking-wide"
+                    >
+                      {{ cat }}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </aside>
+
+          <!-- ── CENTER: Main Editorial Content ────────────────────────── -->
+          <div class="xl:px-8 space-y-8 min-w-0">
             <!-- Main Hero Image Frame -->
             <div class="editorial-card">
               <div class="editorial-card__inner overflow-hidden bg-bone border border-stroke p-0">
@@ -160,45 +164,23 @@
             @close="closeLightbox"
           />
 
-          <!-- Right Column: Sticky Spec Rail & Metrics (Col 4) -->
-          <aside class="lg:col-span-4 space-y-6 lg:sticky lg:top-24">
-            <!-- Specs Card -->
+          <!-- ── RIGHT RAIL: Tech Stack + CTA (sticky) ──────────────────── -->
+          <aside
+            class="xl:sticky xl:top-24 xl:self-start
+                   xl:pl-4 xl:pr-1
+                   space-y-4
+                   mt-6 xl:mt-0"
+          >
             <div class="editorial-card">
-              <div class="editorial-card__inner p-6 space-y-6">
+              <div class="editorial-card__inner p-5 space-y-5">
                 <div class="flex items-center justify-between pb-3 border-b border-stroke">
-                  <h2 class="text-sm font-mono uppercase tracking-widest text-ink-tertiary">System Spec Rail</h2>
-                  <span class="w-1.5 h-1.5 rounded-full" :class="project.liveUrl ? 'bg-pastel-green-text animate-pulse-soft' : 'bg-ink-tertiary'"></span>
-                </div>
-
-                <!-- Status & Lifecycle -->
-                <div class="grid grid-cols-2 gap-2 text-xs font-mono">
-                  <div class="p-3 rounded-lg bg-bone border border-stroke">
-                    <span class="text-[10px] text-ink-tertiary uppercase block">Status</span>
-                    <span class="text-ink mt-1 block font-medium">{{ project.liveUrl ? 'Active in Prod' : 'Completed' }}</span>
-                  </div>
-                  <div class="p-3 rounded-lg bg-bone border border-stroke">
-                    <span class="text-[10px] text-ink-tertiary uppercase block">Timeline</span>
-                    <span class="text-ink mt-1 block tabular-nums">{{ project.duration || '2025' }}</span>
-                  </div>
-                </div>
-
-                <!-- Category Tags -->
-                <div v-if="project.categories && project.categories.length" class="space-y-2">
-                  <span class="text-[10px] font-mono text-ink-tertiary uppercase tracking-wider block">Domain Classification</span>
-                  <div class="flex flex-wrap gap-1.5">
-                    <span
-                      v-for="cat in project.categories"
-                      :key="cat"
-                      class="px-2.5 py-1 rounded-full bg-pastel-blue text-pastel-blue-text text-[10px] font-mono tracking-wide"
-                    >
-                      {{ cat }}
-                    </span>
-                  </div>
+                  <h2 class="text-[10px] font-mono uppercase tracking-widest text-ink-tertiary">Tech Stack</h2>
+                  <span class="w-1.5 h-1.5 rounded-full bg-pastel-amber-text"></span>
                 </div>
 
                 <!-- Technology Matrix -->
                 <div class="space-y-2">
-                  <span class="text-[10px] font-mono text-ink-tertiary uppercase tracking-wider block">Technologies &amp; Libraries</span>
+                  <span class="text-[10px] font-mono text-ink-tertiary uppercase tracking-wider block">Core Technologies</span>
                   <div class="flex flex-wrap gap-1.5">
                     <span
                       v-for="tech in project.technologies"
@@ -219,7 +201,7 @@
                     rel="noopener noreferrer"
                     class="group w-full py-2.5 px-4 rounded-md bg-ink text-surface font-sans font-medium text-xs flex items-center justify-center gap-2 active:scale-[0.98] transition-all"
                   >
-                    <span>Launch Live Demo</span>
+                    <span>Launch Live App</span>
                     <span class="w-4 h-4 rounded-full bg-surface/20 flex items-center justify-center group-hover:translate-x-0.5 group-hover:-translate-y-px transition-transform duration-200">
                       <svg class="w-2.5 h-2.5" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M2.5 9.5 9.5 2.5M5 2.5h4.5V7"/>
@@ -234,7 +216,7 @@
                     rel="noopener noreferrer"
                     class="w-full py-2.5 px-4 rounded-md bg-bone border border-stroke text-ink-secondary font-sans font-medium text-xs text-center hover:border-ink/20 hover:text-ink active:scale-[0.98] transition-all block"
                   >
-                    View Source Code
+                    Repository
                   </a>
                 </div>
               </div>
@@ -327,4 +309,3 @@ watch(
   { immediate: true },
 )
 </script>
-

--- a/fe/src/views/ProjectsView.vue
+++ b/fe/src/views/ProjectsView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-[100dvh] bg-canvas">
-    <div class="max-w-5xl mx-auto px-4 sm:px-6 py-8 sm:py-12 space-y-10 sm:space-y-12">
+    <div class="w-full max-w-[1600px] mx-auto px-3 sm:px-6 py-8 sm:py-12 space-y-10 sm:space-y-12">
       <!-- ── Page Header: Avant-Garde Editorial Architecture ─────────── -->
       <header class="editorial-card">
         <div class="editorial-card__inner p-8 sm:p-14 flex flex-col justify-between gap-8">
@@ -80,12 +80,18 @@
           v-for="(project, index) in projectsStore.projects"
           :key="project._id"
           :class="[
-            index % 6 === 0 ? 'col-span-12 lg:col-span-8' : (index % 6 === 1 ? 'col-span-12 lg:col-span-4' : (index % 6 === 2 ? 'col-span-12 lg:col-span-4' : 'col-span-12 lg:col-span-8'))
+            index % 6 === 0 ? 'col-span-12 xl:col-span-7' :
+            index % 6 === 1 ? 'col-span-12 xl:col-span-5' :
+            index % 6 === 2 ? 'col-span-12 md:col-span-5 xl:col-span-4' :
+            index % 6 === 3 ? 'col-span-12 md:col-span-7 xl:col-span-8' :
+            index % 6 === 4 ? 'col-span-12 xl:col-span-8' :
+                               'col-span-12 xl:col-span-4'
           ]"
         >
           <ProjectCard :project="project" :layout="getMasonryLayout(index)" />
         </div>
       </div>
+
 
       <!-- Empty State -->
       <div v-else class="editorial-card">


### PR DESCRIPTION
Closes #25

## Summary of Changes

### ProjectDetailView — 3-column sticky rail architecture
- Outer wrapper: max-w-[1720px] (was max-w-5xl) — full-bleed editorial canvas
- xl:grid-cols-[220px_1fr_200px] 3-column layout at xl+ breakpoint
- **Left rail**: System Spec Rail — xl:sticky xl:top-24, anchored near left edge (xl:pl-1 xl:pr-4). Contains: Status, Timeline, Domain Classification
- **Center**: Main editorial content (hero image, Executive Overview, Architecture Dossier)
- **Right rail**: New Tech Stack + CTA card — xl:sticky xl:top-24, anchored near right edge (xl:pl-4 xl:pr-1). Contains: Core Technologies pill grid, Launch Live App button, Repository link
- Below xl: single-column stacking (left rail → center → right rail)

### ProjectsView & BlogView — Full-bleed layouts
- Expanded from max-w-5xl to max-w-[1600px]
- Masonry grid refined: 7/5 → 4/8 → 8/4 col-span asymmetry at xl+ (was lg-only 8/4)
- Cards bleed edge-to-edge on wide viewports

### AboutView — Sticky-left avatar rail
- Expanded to max-w-[1600px]
- Avatar + social links card moved to xl:grid-cols-[220px_1fr] sticky-left column (mirrors System Spec Rail pattern)
- Bio/skills content fills remaining right space

### ScrollToTopButton.vue — Global FAB (NEW)
- position: fixed; bottom: 1.75rem; right: 1.75rem
- Appears after 300px scroll depth via scroll event listener (passive)
- Slide-up + fade <Transition> (only 	ransform + opacity, 60fps GPU rule)
- Elastic spring hover: cubic-bezier(0.34, 1.56, 0.64, 1)
- Registered in App.vue, hidden on admin routes via -if='!isAdminRoute'

## Testing & Verification
- [x] Backend TypeScript build passed (
pm run build in ackend/)
- [x] Automated seam tests passed — 5/5 PASS (
ode ./scripts/test-seams.mjs in e/)
- [x] Frontend build + SEO prerender passed — 25 pages (
pm run build in e/)