### PR TITLE
feat(layout): expand navbar width, refine container side margins, and verify dynamic data binding

### DIFF
--- a/fe/src/components/layout/Navbar.vue
+++ b/fe/src/components/layout/Navbar.vue
@@ -1,24 +1,28 @@
 <template>
-  <header class="sticky top-0 z-[200] w-full flex justify-center pt-5 px-4 pointer-events-none">
-    <!-- Floating Island Pill -->
+  <header class="sticky top-0 z-[200] w-full flex justify-center pt-4 sm:pt-6 px-4 sm:px-6 pointer-events-none">
+    <!-- Floating Island Pill (Expanded Architecture) -->
     <div
-      class="pointer-events-auto flex items-center justify-between gap-6 px-4 py-2.5 rounded-full bg-surface/90 border border-stroke shadow-island w-full max-w-3xl backdrop-blur-md transition-all duration-[500ms] ease-[cubic-bezier(0.32,0.72,0,1)]"
+      class="pointer-events-auto flex items-center justify-between gap-4 sm:gap-8 px-5 sm:px-8 py-3 rounded-full bg-surface/90 border border-stroke shadow-island w-full max-w-4xl lg:max-w-5xl xl:max-w-6xl backdrop-blur-md transition-all duration-[500ms] ease-[cubic-bezier(0.32,0.72,0,1)]"
       :class="isScrolled ? 'shadow-island-hover border-stroke/90' : 'shadow-island'"
     >
       <!-- Logo & Brand -->
-      <RouterLink to="/" class="flex items-center gap-2.5 group active:scale-[0.98] transition-transform duration-200">
+      <RouterLink to="/" class="flex items-center gap-2.5 sm:gap-3 group active:scale-[0.98] transition-transform duration-200">
         <!-- Double-bezel logo mark -->
-        <div class="w-8 h-8 rounded-full bg-bone border border-stroke flex items-center justify-center shadow-[inset_0_1px_1px_rgba(255,255,255,0.1)] group-hover:border-ink/30 transition-colors duration-300">
-          <span class="font-mono text-ink text-xs font-semibold tracking-tighter">T/</span>
+        <div class="w-8 h-8 sm:w-9 sm:h-9 rounded-full bg-bone border border-stroke flex items-center justify-center shadow-[inset_0_1px_1px_rgba(255,255,255,0.1)] group-hover:border-ink/30 transition-colors duration-300">
+          <span class="font-mono text-ink text-xs sm:text-sm font-semibold tracking-tighter">T/</span>
         </div>
         <div class="flex flex-col leading-none">
-          <span class="font-sans font-semibold text-sm tracking-tight text-ink group-hover:text-ink/80 transition-colors duration-300">Hồ Ngọc Thiện</span>
-          <span class="font-mono text-[9px] text-ink-tertiary tracking-widest uppercase">Portfolio</span>
+          <span class="font-sans font-semibold text-sm sm:text-base tracking-tight text-ink group-hover:text-ink/80 transition-colors duration-300">
+            {{ aboutStore.aboutData?.name || 'Hồ Ngọc Thiện' }}
+          </span>
+          <span class="font-mono text-[9px] text-ink-tertiary tracking-widest uppercase">
+            {{ aboutStore.aboutData?.title || 'Full Stack Engineer' }}
+          </span>
         </div>
       </RouterLink>
 
       <!-- Desktop Nav Links -->
-      <nav class="hidden md:flex items-center gap-0.5 font-sans text-sm font-medium" aria-label="Main Navigation">
+      <nav class="hidden md:flex items-center gap-1 lg:gap-2 font-sans text-sm font-medium" aria-label="Main Navigation">
         <RouterLink
           v-for="link in navLinks"
           :key="link.to"
@@ -132,7 +136,9 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
 import { useCommandPalette } from '@/composables/useCommandPalette'
+import { useAboutStore } from '@/stores/about'
 
+const aboutStore = useAboutStore()
 const { openPalette } = useCommandPalette()
 const isMobileMenuOpen = ref(false)
 const isScrolled = ref(false)

--- a/fe/src/views/AboutView.vue
+++ b/fe/src/views/AboutView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-[100dvh] bg-canvas">
-    <div class="w-full max-w-[1600px] mx-auto px-3 sm:px-6 py-8 sm:py-14 space-y-12 sm:space-y-16">
+    <div class="w-full max-w-[1380px] mx-auto px-6 sm:px-10 lg:px-12 py-8 sm:py-14 space-y-12 sm:space-y-16">
 
       <!-- ── Page Header: Avant-Garde Profile Masthead ────────────────── -->
       <header class="editorial-card">

--- a/fe/src/views/BlogView.vue
+++ b/fe/src/views/BlogView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-[100dvh] bg-canvas">
-    <div class="w-full max-w-[1600px] mx-auto px-3 sm:px-6 py-8 sm:py-14 space-y-10 sm:space-y-12">
+    <div class="w-full max-w-[1380px] mx-auto px-6 sm:px-10 lg:px-12 py-8 sm:py-14 space-y-12 sm:space-y-16">
 
       <!-- ── Page Header: Avant-Garde Publication Masthead ───────────── -->
       <header class="editorial-card">
@@ -106,7 +106,7 @@
 
       <div
         v-else-if="blogStore.posts.length"
-        class="grid grid-cols-1 md:grid-cols-12 gap-6"
+        class="grid grid-cols-1 md:grid-cols-12 gap-7 sm:gap-8"
       >
         <div
           v-for="(post, index) in blogStore.posts"

--- a/fe/src/views/HomeView.vue
+++ b/fe/src/views/HomeView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-[100dvh] bg-canvas">
-    <div class="max-w-5xl mx-auto px-4 sm:px-6 py-10 sm:py-14 space-y-24 sm:space-y-32">
+    <div class="w-full max-w-[1380px] mx-auto px-6 sm:px-10 lg:px-12 py-10 sm:py-14 space-y-24 sm:space-y-32">
 
       <!-- ── Hero Section ────────────────────────────────────────────── -->
       <HeroSection :data="homeStore.homeData || {}" />

--- a/fe/src/views/ProjectDetailView.vue
+++ b/fe/src/views/ProjectDetailView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="min-h-[100dvh] bg-canvas">
-    <!-- Outer full-bleed wrapper -->
-    <div class="w-full max-w-[1720px] mx-auto px-3 sm:px-6 py-8 sm:py-12">
+    <!-- Outer balanced canvas wrapper -->
+    <div class="w-full max-w-[1440px] mx-auto px-6 sm:px-10 lg:px-12 py-8 sm:py-12">
       <LoadingSpinner v-if="loading" />
 
       <div v-else-if="project" class="space-y-8">

--- a/fe/src/views/ProjectsView.vue
+++ b/fe/src/views/ProjectsView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-[100dvh] bg-canvas">
-    <div class="w-full max-w-[1600px] mx-auto px-3 sm:px-6 py-8 sm:py-14 space-y-10 sm:space-y-12">
+    <div class="w-full max-w-[1380px] mx-auto px-6 sm:px-10 lg:px-12 py-8 sm:py-14 space-y-12 sm:space-y-16">
 
       <!-- ── Page Header: Avant-Garde Editorial Masthead ─────────────── -->
       <header class="editorial-card">
@@ -108,7 +108,7 @@
 
       <div
         v-else-if="projectsStore.projects.length"
-        class="grid grid-cols-1 md:grid-cols-12 gap-6"
+        class="grid grid-cols-1 md:grid-cols-12 gap-7 sm:gap-8"
       >
         <div
           v-for="(project, index) in projectsStore.projects"


### PR DESCRIPTION
Closes #31

## Summary of Changes
- **Navbar.vue**: Expand floating island pill from \max-w-3xl\ to \max-w-4xl lg:max-w-5xl xl:max-w-6xl\ with \px-5 sm:px-8 py-3\ padding. Bind author name and title dynamically to \boutStore\.
- **ProjectsView.vue**: Adjust container to \max-w-[1380px]\ with \px-6 sm:px-10 lg:px-12\ side margins, \gap-7 sm:gap-8\ grid spacing, and \space-y-12 sm:space-y-16\ vertical rhythm.
- **BlogView.vue**: Adjust container to \max-w-[1380px]\ with \px-6 sm:px-10 lg:px-12\ side margins and \gap-7 sm:gap-8\.
- **AboutView.vue & HomeView.vue**: Adjust container to \max-w-[1380px]\ with \px-6 sm:px-10 lg:px-12\.
- **ProjectDetailView.vue**: Adjust container to \max-w-[1440px]\ with \px-6 sm:px-10 lg:px-12\.

## Testing & Verification
- [x] Backend TypeScript build passed
- [x] Automated seam tests passed (5/5 PASS)
- [x] Frontend build & SEO prerender passed (25 pages)