### PR TITLE
feat(about): rename work chronology heading to experience and display updated career history

### DIFF
--- a/fe/src/views/AboutView.vue
+++ b/fe/src/views/AboutView.vue
@@ -207,7 +207,7 @@
                     <span class="status-dot"></span>
                     Professional Trajectory
                   </span>
-                  <h2 class="text-2xl sm:text-4xl font-serif font-light text-ink">Work Chronology</h2>
+                  <h2 class="text-2xl sm:text-4xl font-serif font-light text-ink">Experience</h2>
                 </div>
                 <span class="text-[10px] font-mono text-ink-tertiary uppercase tracking-wider">Verified Track Record</span>
               </div>


### PR DESCRIPTION
Closes #35

## Summary of Changes
- **AboutView.vue**: Renamed \Work Chronology\ heading to \Experience\ per user specification.
- **MongoDB Atlas**: Updated live career records for DIGIFNB, FPT University, and FPT Software with detailed responsibilities and technologies.

## Testing & Verification
- [x] Backend TypeScript build passed
- [x] Automated seam tests passed (5/5 PASS)
- [x] Frontend build & SEO prerender passed (25 pages)